### PR TITLE
Backwards compatibility with Litecoin privatekeys

### DIFF
--- a/js/SimpleDeps.js
+++ b/js/SimpleDeps.js
@@ -12458,12 +12458,26 @@ CryptoJS.pad.Iso10126 = {
 					feePerKb: 1e4,
 					estimateFee: estimateFee("testnet")
 				},
+				litecoin: {
+					magicPrefix: "Litecoin Signed Message:\n",
+					bip32: {
+						"public": 27108450,
+						"private": 27106558
+				    	},
+					pubKeyHash: 48,
+					scriptHash: 5,
+					wif: 176,
+					dustThreshold: 0,
+					dustSoftThreshold: 1e5,
+					feePerKb: 1e5,
+					estimateFee: estimateFee("litecoin")
+				},
 				florincoin: {
 					magicPrefix: "\x1bFlorincoin Signed Message:\n",
-					bip32: {"public": 27108450, "private": 27106558},
+					bip32: {"public": 27108450, "private": 27106558}, // ToDo: Look into this.
 					pubKeyHash: 35,
 					scriptHash: 8,
-					wif: 176,
+					wif: 163,
 					dustThreshold: 0,
 					dustSoftThreshold: 1e5,
 					feePerKb: 1e5,

--- a/js/SimpleWallet.js
+++ b/js/SimpleWallet.js
@@ -315,6 +315,12 @@ var Wallet = (function () {
 				version = this.coin_network.pubKeyHash;
 			}
 			var decoded = Bitcoin.base58check.decode(key);
+			
+			if( this.coin_network == Bitcoin.networks.florincoin && priv == true) {
+				// Backwards compatibility for private keys saved under litecoin settings.
+				return decoded[0] == Bitcoin.networks.florincoin.wif || decoded[0] == Bitcoin.networks.litecoin.wif
+			}
+			
 			// is this address for the right network?
 			return (decoded[0] == version);
 		}


### PR DESCRIPTION
Early versions of fluffy-enigma/flo-vault incorrectly used Litecoin parameters when generating some private keys - accept both forms as valid